### PR TITLE
fix(ci): update GitHub Actions for Pages deployment

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -39,10 +39,9 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: 'out/'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
-
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Old versions no longer support GitHub Pages deployment

Upgrade upload-pages-artifact from v1 to v3
Upgrade deploy-pages from v1 to v4